### PR TITLE
konflux: modify default builder and target images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use OpenShift golang builder image
 # These images needs to be synced with the images in the Makefile.
-ARG BUILDER_IMAGE=${BUILDER_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17}
-ARG TARGET_IMAGE=${TARGET_IMAGE:-registry.ci.openshift.org/ocp/4.17:base}
+ARG BUILDER_IMAGE=${BUILDER_IMAGE:-registry.access.redhat.com/ubi9/go-toolset:1.22.7-1733160835}
+ARG TARGET_IMAGE=${TARGET_IMAGE:-registry.access.redhat.com/ubi9/ubi-micro}
 FROM ${BUILDER_IMAGE} AS builder
 
 WORKDIR /workspace


### PR DESCRIPTION
We have authentication errors when using redhat.ci.openshift.org images from the konflux instance.
Fixing it (temporarily?) with public images.
